### PR TITLE
Refactor theme colors extension and fix import in home screen

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:theme_app/main.dart';
+import 'package:theme_app/theme/colors_extension.dart';
 
-import 'theme/custom_colors_extension.dart';
 import 'theme/tw_theme.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -9,12 +9,9 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final customColorsExtension =
-        Theme.of(context).extension<CustomColorsExtension>()!;
-    final primaryColor =
-        customColorsExtension.colorsModel.primary.primaryColor.value!;
+    final primaryColor = context.colorsExtension.primary.primaryColor.value!;
     final secondaryButton =
-        customColorsExtension.colorsModel.button.secondaryButton.value!;
+        context.colorsExtension.button.secondaryButton.value!;
     return Scaffold(
       backgroundColor: primaryColor,
       appBar: AppBar(

--- a/lib/theme/colors_extension.dart
+++ b/lib/theme/colors_extension.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:theme_app/theme/colors_model.dart';
+
+import 'custom_colors_extension.dart';
+
+extension ThemeExtension on BuildContext {
+  ColorsModel get colorsExtension {
+    final customColorsExtension =
+        Theme.of(this).extension<CustomColorsExtension>()!;
+    return customColorsExtension.colorsModel;
+  }
+}

--- a/lib/theme/colors_model.dart
+++ b/lib/theme/colors_model.dart
@@ -1,13 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import '../tw_constents.dart';
-
-ColorsModel colorsModelsFromJson(String str) =>
-    ColorsModel.fromJson(json.decode(str));
-
-String colorsModelsToJson(ColorsModel data) => json.encode(data.toJson());
 
 class ColorsModel {
   final PrimaryModel primary;


### PR DESCRIPTION
The commit refactors the theme colors extension to be more concise and adds a new file `colors_extension.dart`. The import in `home_screen.dart` is also fixed to use the new extension.